### PR TITLE
Push images to DockerHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,13 @@ name: ci
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  pull_request: {}
 
 env:
   DOCKER_IMAGE_NAME: app
-  DOCKER_REGISTRY: docker.pkg.github.com
-  PACKAGE_REPO: doxavore/chasqui
+  DOCKER_REGISTRY: docker.io
+  DOCKER_REGISTRY_USER: doxavore
+  DOCKER_REPO: doxavore/chasqui
   RAILS_ENV: test
 
 jobs:
@@ -20,16 +20,20 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set full docker image name
-        run: echo "::set-env name=FULL_DOCKER_IMAGE::$DOCKER_REGISTRY/$PACKAGE_REPO/$DOCKER_IMAGE_NAME:$GITHUB_SHA"
+        run: echo "::set-env name=FULL_DOCKER_IMAGE::$DOCKER_REPO:$DOCKER_IMAGE_NAME-$GITHUB_SHA"
 
       - name: Build docker image
         run: |
           docker build -t "$FULL_DOCKER_IMAGE" .
 
-      - name: Push docker image to GitHub Package Registry
-        if: github.repository == env.PACKAGE_REPO
+      - name: Authenticate to Docker Hub
+        if: github.repository == env.DOCKER_REPO
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u ${{ github.actor }} --password-stdin "$DOCKER_REGISTRY"
+          echo "${{ secrets.DOCKER_HUB_KEY }}" | docker login -u $DOCKER_REGISTRY_USER --password-stdin "$DOCKER_REGISTRY"
+
+      - name: Push docker image to Docker Hub
+        if: github.repository == env.DOCKER_REPO
+        run: |
           docker push "$FULL_DOCKER_IMAGE"
 
       - name: Docker log out
@@ -46,11 +50,11 @@ jobs:
 
     steps:
       - name: Set full docker image name
-        run: echo ::set-env name=FULL_DOCKER_IMAGE::$DOCKER_REGISTRY/$PACKAGE_REPO/$DOCKER_IMAGE_NAME:$GITHUB_SHA
+        run: echo "::set-env name=FULL_DOCKER_IMAGE::$DOCKER_REPO:$DOCKER_IMAGE_NAME-$GITHUB_SHA"
 
       - name: Pull Docker image
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u ${{ github.actor }} --password-stdin "$DOCKER_REGISTRY"
+          echo "${{ secrets.DOCKER_HUB_KEY }}" | docker login -u $DOCKER_REGISTRY_USER --password-stdin "$DOCKER_REGISTRY"
           docker pull "$FULL_DOCKER_IMAGE"
 
       - name: Run rubocop
@@ -102,7 +106,7 @@ jobs:
         # This doesn't currently work; it's always empty.
         # echo ::set-env name=DOCKER_NETWORK::${{ job.services.network }}
         run: |
-          echo ::set-env name=FULL_DOCKER_IMAGE::$DOCKER_REGISTRY/$PACKAGE_REPO/$DOCKER_IMAGE_NAME:$GITHUB_SHA
+          echo "::set-env name=FULL_DOCKER_IMAGE::$DOCKER_REPO:$DOCKER_IMAGE_NAME-$GITHUB_SHA"
           echo ::set-env name=DOCKER_NETWORK::$(docker inspect -f '{{.HostConfig.NetworkMode}}' ${{ job.services.postgres.id }})
           echo ::set-env name=POSTGRES_ID::${{ job.services.postgres.id }}
           echo ::set-env name=POSTGRES_PORT::${{ job.services.postgres.ports[5432] }}
@@ -110,7 +114,7 @@ jobs:
 
       - name: Pull Docker image
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u ${{ github.actor }} --password-stdin "$DOCKER_REGISTRY"
+          echo "${{ secrets.DOCKER_HUB_KEY }}" | docker login -u $DOCKER_REGISTRY_USER --password-stdin "$DOCKER_REGISTRY"
           docker pull "$FULL_DOCKER_IMAGE"
 
       - name: Set up app
@@ -126,6 +130,33 @@ jobs:
               -e RAILS_ENV -e POSTGRES_HOST -e POSTGRES_PORT -e REDIS_URL \
               "$FULL_DOCKER_IMAGE" \
               bundle exec rspec
+
+      - name: Docker log out
+        if: always()
+        run: |
+          docker logout "$DOCKER_REGISTRY"
+
+  release-candidate:
+    # Can't seem to use env here?
+    if: github.repository == 'doxavore/chasqui' && github.head_ref == 'master'
+    needs:
+      - build
+      - lint
+      - test
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Set full docker image name
+        run: |
+          echo "::set-env name=FULL_DOCKER_IMAGE::$DOCKER_REPO:$DOCKER_IMAGE_NAME-$GITHUB_SHA"
+          echo "::set-env name=LATEST_DOCKER_IMAGE::$DOCKER_REPO:$DOCKER_IMAGE_NAME-latest"
+
+      - name: Tag latest docker image
+        run: |
+          echo "${{ secrets.DOCKER_HUB_KEY }}" | docker login -u $DOCKER_REGISTRY_USER --password-stdin "$DOCKER_REGISTRY"
+          docker pull "$FULL_DOCKER_IMAGE"
+          docker tag "$FULL_DOCKER_IMAGE" "$LATEST_DOCKER_IMAGE"
+          docker push "$LATEST_DOCKER_IMAGE"
 
       - name: Docker log out
         if: always()


### PR DESCRIPTION
GitHub's package repo has very low limits that seem they could sneak up, so push images to DockerHub instead.

- Test build forcing the branch to tag latest: https://github.com/doxavore/chasqui/actions/runs/77696488
- Pushed image: https://hub.docker.com/layers/doxavore/chasqui/app-latest/images/sha256-ce92e02e622df5ea18450d1d78172819ba78a38d9c259519d00ee0b27096cc62?context=repo
- Build skipping RC after filtering for only master branch: https://github.com/doxavore/chasqui/actions/runs/77698330

Using `i18n-tasks` branch as a temporary base to avoid workflow file conflicts; reset to master.